### PR TITLE
[Feature 2] 영화 내용 상세 화면을 보여줍니다

### DIFF
--- a/NaverMovieSearch.xcodeproj/project.pbxproj
+++ b/NaverMovieSearch.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 		DE5695942858D47A009F3DCE /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5695932858D47A009F3DCE /* MockURLSession.swift */; };
 		DE5695962858D51B009F3DCE /* MockNetworkProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5695952858D51B009F3DCE /* MockNetworkProviderTests.swift */; };
 		DE5695982858DA06009F3DCE /* UICollectionView+Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5695972858DA06009F3DCE /* UICollectionView+Register.swift */; };
-		DE56959A2858DA44009F3DCE /* MovieListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5695992858DA44009F3DCE /* MovieListCell.swift */; };
+		DE56959A2858DA44009F3DCE /* MovieCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5695992858DA44009F3DCE /* MovieCell.swift */; };
 		DE56959C2858E333009F3DCE /* MovieSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE56959B2858E333009F3DCE /* MovieSearchViewModel.swift */; };
 		DE56959F285947CD009F3DCE /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE56959E285947CD009F3DCE /* ImageCacheManager.swift */; };
 		DE5695A12859481B009F3DCE /* UIImage+LoadCachedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5695A02859481B009F3DCE /* UIImage+LoadCachedImage.swift */; };
@@ -78,7 +78,7 @@
 		DE5695932858D47A009F3DCE /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		DE5695952858D51B009F3DCE /* MockNetworkProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkProviderTests.swift; sourceTree = "<group>"; };
 		DE5695972858DA06009F3DCE /* UICollectionView+Register.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Register.swift"; sourceTree = "<group>"; };
-		DE5695992858DA44009F3DCE /* MovieListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieListCell.swift; sourceTree = "<group>"; };
+		DE5695992858DA44009F3DCE /* MovieCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieCell.swift; sourceTree = "<group>"; };
 		DE56959B2858E333009F3DCE /* MovieSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieSearchViewModel.swift; sourceTree = "<group>"; };
 		DE56959E285947CD009F3DCE /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		DE5695A02859481B009F3DCE /* UIImage+LoadCachedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+LoadCachedImage.swift"; sourceTree = "<group>"; };
@@ -185,7 +185,7 @@
 			isa = PBXGroup;
 			children = (
 				DE56952F28584EC1009F3DCE /* MovieSearchViewController.swift */,
-				DE5695992858DA44009F3DCE /* MovieListCell.swift */,
+				DE5695992858DA44009F3DCE /* MovieCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -440,7 +440,7 @@
 				DE56959F285947CD009F3DCE /* ImageCacheManager.swift in Sources */,
 				DE5695A12859481B009F3DCE /* UIImage+LoadCachedImage.swift in Sources */,
 				DE56956E28586048009F3DCE /* JSONParser.swift in Sources */,
-				DE56959A2858DA44009F3DCE /* MovieListCell.swift in Sources */,
+				DE56959A2858DA44009F3DCE /* MovieCell.swift in Sources */,
 				DE5695A328595417009F3DCE /* String+Replace.swift in Sources */,
 				DE56955F2858571D009F3DCE /* AppCoordinator.swift in Sources */,
 				DE56959C2858E333009F3DCE /* MovieSearchViewModel.swift in Sources */,

--- a/NaverMovieSearch.xcodeproj/project.pbxproj
+++ b/NaverMovieSearch.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 		DE5695A12859481B009F3DCE /* UIImage+LoadCachedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5695A02859481B009F3DCE /* UIImage+LoadCachedImage.swift */; };
 		DE5695A328595417009F3DCE /* String+Replace.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5695A228595417009F3DCE /* String+Replace.swift */; };
 		DEDF032A285A0AEC000F7915 /* CellItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDF0329285A0AEC000F7915 /* CellItem.swift */; };
+		DEDF032E285A2F0A000F7915 /* DetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDF032D285A2F0A000F7915 /* DetailCoordinator.swift */; };
+		DEDF0334285A3419000F7915 /* MovieDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDF0333285A3419000F7915 /* MovieDetailViewController.swift */; };
+		DEDF0336285AABFC000F7915 /* MoviewDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDF0335285AABFC000F7915 /* MoviewDetailViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +84,9 @@
 		DE5695A02859481B009F3DCE /* UIImage+LoadCachedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+LoadCachedImage.swift"; sourceTree = "<group>"; };
 		DE5695A228595417009F3DCE /* String+Replace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Replace.swift"; sourceTree = "<group>"; };
 		DEDF0329285A0AEC000F7915 /* CellItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellItem.swift; sourceTree = "<group>"; };
+		DEDF032D285A2F0A000F7915 /* DetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCoordinator.swift; sourceTree = "<group>"; };
+		DEDF0333285A3419000F7915 /* MovieDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailViewController.swift; sourceTree = "<group>"; };
+		DEDF0335285AABFC000F7915 /* MoviewDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviewDetailViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +158,7 @@
 			children = (
 				DE56955E2858571D009F3DCE /* AppCoordinator.swift */,
 				DE5695552858561E009F3DCE /* Search */,
+				DEDF032C285A2D91000F7915 /* Detail */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -266,6 +273,32 @@
 				DE56959E285947CD009F3DCE /* ImageCacheManager.swift */,
 			);
 			path = Utility;
+			sourceTree = "<group>";
+		};
+		DEDF032C285A2D91000F7915 /* Detail */ = {
+			isa = PBXGroup;
+			children = (
+				DEDF032D285A2F0A000F7915 /* DetailCoordinator.swift */,
+				DEDF032F285A2F16000F7915 /* View */,
+				DEDF0330285A2F1D000F7915 /* ViewModel */,
+			);
+			path = Detail;
+			sourceTree = "<group>";
+		};
+		DEDF032F285A2F16000F7915 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				DEDF0333285A3419000F7915 /* MovieDetailViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		DEDF0330285A2F1D000F7915 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				DEDF0335285AABFC000F7915 /* MoviewDetailViewModel.swift */,
+			);
+			name = ViewModel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -398,6 +431,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DEDF032E285A2F0A000F7915 /* DetailCoordinator.swift in Sources */,
 				DEDF032A285A0AEC000F7915 /* CellItem.swift in Sources */,
 				DE5695702858607F009F3DCE /* NaverMovieAPI.swift in Sources */,
 				DE56956628585F9C009F3DCE /* APIProtocol.swift in Sources */,
@@ -416,7 +450,9 @@
 				DE56956B28586001009F3DCE /* URLRequest+Initializer.swift in Sources */,
 				DE56952C28584EC1009F3DCE /* AppDelegate.swift in Sources */,
 				DE5695982858DA06009F3DCE /* UICollectionView+Register.swift in Sources */,
+				DEDF0336285AABFC000F7915 /* MoviewDetailViewModel.swift in Sources */,
 				DE5695612858591B009F3DCE /* SearchCoordinator.swift in Sources */,
+				DEDF0334285A3419000F7915 /* MovieDetailViewController.swift in Sources */,
 				DE56952E28584EC1009F3DCE /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NaverMovieSearch/App/SceneDelegate.swift
+++ b/NaverMovieSearch/App/SceneDelegate.swift
@@ -20,7 +20,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = navigationController
         
         appCoordinator = AppCoordinator(navigationController: navigationController)
-        appCoordinator?.start()
+        guard let appCoordinator = appCoordinator as? AppCoordinator else { return }
+
+        appCoordinator.start()
     }
 
 }

--- a/NaverMovieSearch/Info.plist
+++ b/NaverMovieSearch/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/NaverMovieSearch/Presentation/Detail/DetailCoordinator.swift
+++ b/NaverMovieSearch/Presentation/Detail/DetailCoordinator.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+protocol DetailCoordinatorDelegate: AnyObject {
+    
+    func removeFromChildCoordinators(coordinator: CoordinatorDescribing)
+    
+}
+
+final class DetailCoordinator: CoordinatorDescribing {
+    
+    // MARK: - Properties
+    var childCoordinators: [CoordinatorDescribing] = []
+    var navigationController: UINavigationController?
+    weak var delegate: DetailCoordinatorDelegate!
+    
+    // MARK: - Initializers
+    init(navigationController: UINavigationController?) {
+        self.navigationController = navigationController
+    }
+    
+    // MARK: - Methods
+    func start(with item: (movie: CellItem, indexPath: IndexPath), delegatee: MovieSearchViewController) {
+        let movieDetailViewModel = MovieDetailViewModel(movie: item.movie)
+        let movieDetailViewController = MovieDetailViewController(
+            viewModel: movieDetailViewModel,
+            selectedIndexPath: item.indexPath,
+            coordinator: self
+        )
+        movieDetailViewController.delegate = delegatee
+        
+        navigationController?.pushViewController(movieDetailViewController, animated: false)
+    }
+    
+    func finish() {
+        delegate.removeFromChildCoordinators(coordinator: self)
+    }
+    
+}

--- a/NaverMovieSearch/Presentation/Detail/MoviewDetailViewModel.swift
+++ b/NaverMovieSearch/Presentation/Detail/MoviewDetailViewModel.swift
@@ -12,13 +12,13 @@ final class MovieDetailViewModel {
     
     // MARK: - Properties
     private let movie: CellItem
-    private let disposeBag = DisposeBag()
     
     // MARK: - Initializers
     init(movie: CellItem) {
         self.movie = movie
     }
     
+    // MARK: - Methods
     func transform() -> Output {
         let movieInformation = configureMovieInformation()
         let ouput = Output(movieInformation: movieInformation)

--- a/NaverMovieSearch/Presentation/Detail/MoviewDetailViewModel.swift
+++ b/NaverMovieSearch/Presentation/Detail/MoviewDetailViewModel.swift
@@ -1,0 +1,33 @@
+import Foundation
+import RxSwift
+
+final class MovieDetailViewModel {
+    
+    // MARK: - NestedType
+    struct Output {
+        
+        let movieInformation: Observable<[CellItem]>
+        
+    }
+    
+    // MARK: - Properties
+    private let movie: CellItem
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - Initializers
+    init(movie: CellItem) {
+        self.movie = movie
+    }
+    
+    func transform() -> Output {
+        let movieInformation = configureMovieInformation()
+        let ouput = Output(movieInformation: movieInformation)
+        
+        return ouput
+    }
+    
+    private func configureMovieInformation() -> Observable<[CellItem]> {
+        return Observable.just([movie])
+    }
+    
+}

--- a/NaverMovieSearch/Presentation/Detail/View/MovieDetailViewController.swift
+++ b/NaverMovieSearch/Presentation/Detail/View/MovieDetailViewController.swift
@@ -17,10 +17,10 @@ class MovieDetailViewController: UIViewController {
         collectionViewLayout: UICollectionViewLayout()
     )
     private let detailWebView = WKWebView()
+    private let disposeBag = DisposeBag()
     private var viewModel: MovieDetailViewModel!
     private var coordinator: DetailCoordinator!
     private var selectedIndexPath: IndexPath!
-    private let disposeBag = DisposeBag()
     
     // MARK: - Initializers
     convenience init(viewModel: MovieDetailViewModel, selectedIndexPath: IndexPath, coordinator: DetailCoordinator) {
@@ -74,7 +74,7 @@ class MovieDetailViewController: UIViewController {
     
     private func configureCollectionView() {
         informationCollectionview.translatesAutoresizingMaskIntoConstraints = false
-        informationCollectionview.register(cellClass: MovieListCell.self)
+        informationCollectionview.register(cellClass: MovieCell.self)
         informationCollectionview.collectionViewLayout = createCollectionViewLayout()
     }
     
@@ -109,6 +109,7 @@ class MovieDetailViewController: UIViewController {
 
 // MARK: - Binding Methods
 extension MovieDetailViewController {
+    
     private func bind() {
         let output = viewModel.transform()
         
@@ -118,8 +119,8 @@ extension MovieDetailViewController {
     private func configureMovieDetailContent(with movieInformation: Observable<[CellItem]>) {
         movieInformation
             .bind(to: informationCollectionview.rx.items(
-                cellIdentifier: String(describing: MovieListCell.self),
-                cellType: MovieListCell.self
+                cellIdentifier: String(describing: MovieCell.self),
+                cellType: MovieCell.self
             )) { [weak self] _, item, cell in
                 cell.delegate = self
                 cell.apply(item: item)
@@ -136,11 +137,12 @@ extension MovieDetailViewController {
             detailWebView.load(urlRequest)
         }
     }
+    
 }
 
 extension MovieDetailViewController: MovieListCellDelegate {
     
-    func starButtonDidTap(at cell: MovieListCell, isSelected: Bool) {
+    func starButtonDidTap(at cell: MovieCell, isSelected: Bool) {
         delegate.starButtonDidTap(at: selectedIndexPath, isSelected: isSelected)
     }
     

--- a/NaverMovieSearch/Presentation/Detail/View/MovieDetailViewController.swift
+++ b/NaverMovieSearch/Presentation/Detail/View/MovieDetailViewController.swift
@@ -1,0 +1,161 @@
+import RxSwift
+import UIKit
+import WebKit
+
+protocol MovieDetailViewControllerDelegate: AnyObject {
+    
+    func starButtonDidTap(at indexPath: IndexPath, isSelected: Bool)
+    
+}
+
+class MovieDetailViewController: UIViewController {
+    
+    // MARK: - Properties
+    weak var delegate: MovieDetailViewControllerDelegate!
+    private let informationCollectionview = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewLayout()
+    )
+    private let detailWebView = WKWebView()
+    private var viewModel: MovieDetailViewModel!
+    private var coordinator: DetailCoordinator!
+    private var selectedIndexPath: IndexPath!
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - Initializers
+    convenience init(viewModel: MovieDetailViewModel, selectedIndexPath: IndexPath, coordinator: DetailCoordinator) {
+        self.init(nibName: nil, bundle: nil)
+        self.viewModel = viewModel
+        self.selectedIndexPath = selectedIndexPath
+        self.coordinator = coordinator
+    }
+    
+    // MARK: - Deinitializers
+    deinit {
+        coordinator.finish()
+    }
+    
+    // MARK: - Lifecycle Methods
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigationBar()
+        bind()
+        configureUI()
+        configureCollectionView()
+    }
+    
+    // MARK: - Methods
+    private func configureNavigationBar() {
+        let backButton: UIButton = {
+            let button = UIButton()
+            button.setTitle("", for: .normal)
+            return button
+        }()
+        navigationItem.backBarButtonItem = UIBarButtonItem(customView: backButton)
+    }
+    
+    private func configureUI() {
+        view.addSubview(informationCollectionview)
+        view.addSubview(detailWebView)
+        detailWebView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            informationCollectionview.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            informationCollectionview.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            informationCollectionview.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            informationCollectionview.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.15),
+            
+            detailWebView.topAnchor.constraint(equalTo: informationCollectionview.bottomAnchor),
+            detailWebView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            detailWebView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            detailWebView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+    }
+    
+    private func configureCollectionView() {
+        informationCollectionview.translatesAutoresizingMaskIntoConstraints = false
+        informationCollectionview.register(cellClass: MovieListCell.self)
+        informationCollectionview.collectionViewLayout = createCollectionViewLayout()
+    }
+    
+    private func createCollectionViewLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout { _, _ -> NSCollectionLayoutSection in
+            let itemSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .fractionalHeight(1.0)
+            )
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            item.contentInsets = NSDirectionalEdgeInsets(top: 0.5, leading: 0, bottom: 0.5, trailing: 0)
+            
+            let groupSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .fractionalHeight(1.0)
+            )
+            let group = NSCollectionLayoutGroup.horizontal(
+                layoutSize: groupSize,
+                subitem: item,
+                count: 1
+            )
+            
+            let section = NSCollectionLayoutSection(group: group)
+            
+            return section
+        }
+        
+        return layout
+    }
+
+}
+
+// MARK: - Binding Methods
+extension MovieDetailViewController {
+    private func bind() {
+        let output = viewModel.transform()
+        
+        configureMovieDetailContent(with: output.movieInformation)
+    }
+    
+    private func configureMovieDetailContent(with movieInformation: Observable<[CellItem]>) {
+        movieInformation
+            .bind(to: informationCollectionview.rx.items(
+                cellIdentifier: String(describing: MovieListCell.self),
+                cellType: MovieListCell.self
+            )) { [weak self] _, item, cell in
+                cell.delegate = self
+                cell.apply(item: item)
+                cell.hideTitleLablel()
+                self?.loadWebContent(url: item.movie.link)
+                self?.navigationItem.title = item.movie.title.replaceWord
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func loadWebContent(url: String) {
+        if let url = URL(string: url) {
+            let urlRequest = URLRequest(url: url)
+            detailWebView.load(urlRequest)
+        }
+    }
+}
+
+extension MovieDetailViewController: MovieListCellDelegate {
+    
+    func starButtonDidTap(at cell: MovieListCell, isSelected: Bool) {
+        delegate.starButtonDidTap(at: selectedIndexPath, isSelected: isSelected)
+    }
+    
+}
+
+// MARK: - NameSpaces
+extension MovieDetailViewController {
+    
+    private enum Design {
+        
+        static let summaryStackViewHorizontalInset: CGFloat = 10
+        static let summaryStackViewVerticalInset: CGFloat = 15
+        static let summaryStackViewSpacing: CGFloat = 10
+        
+        static let descriptionContentFont: UIFont = .preferredFont(forTextStyle: .body)
+    }
+    
+}

--- a/NaverMovieSearch/Presentation/Search/SearchCoordinator.swift
+++ b/NaverMovieSearch/Presentation/Search/SearchCoordinator.swift
@@ -5,18 +5,37 @@ final class SearchCoordinator: CoordinatorDescribing {
     // MARK: - Properties
     var childCoordinators: [CoordinatorDescribing] = []
     var navigationController: UINavigationController?
+    private var movieSearchViewController: MovieSearchViewController!
     
     // MARK: - Initializers
     init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
     
-    // MARK: - Methos
+    // MARK: - Methods
     func start() {
-        let movieSearchViewModel = MovieSearchViewModel()
-        let movieSearchViewController = MovieSearchViewController(viewModel: movieSearchViewModel)
+        let movieSearchViewModel = MovieSearchViewModel(coordinator: self)
+        movieSearchViewController = MovieSearchViewController(viewModel: movieSearchViewModel)
         
         navigationController?.pushViewController(movieSearchViewController, animated: true)
+    }
+    
+    func showDetailPage(with information: (CellItem, IndexPath)) {
+        let detailCoordinator = DetailCoordinator(navigationController: navigationController)
+        childCoordinators.append(detailCoordinator)
+        detailCoordinator.delegate = self
+        
+        detailCoordinator.start(with: information, delegatee: movieSearchViewController)
+    }
+    
+}
+
+// MARK: - DetailCoordinator Delegate
+extension SearchCoordinator: DetailCoordinatorDelegate {
+    
+    func removeFromChildCoordinators(coordinator: CoordinatorDescribing) {
+        let updatedChildCoordinators = childCoordinators.filter { $0 !== coordinator }
+        childCoordinators = updatedChildCoordinators
     }
     
 }

--- a/NaverMovieSearch/Presentation/Search/View/MovieCell.swift
+++ b/NaverMovieSearch/Presentation/Search/View/MovieCell.swift
@@ -2,11 +2,11 @@ import UIKit
 
 protocol MovieListCellDelegate: AnyObject {
     
-    func starButtonDidTap(at cell: MovieListCell, isSelected: Bool)
+    func starButtonDidTap(at cell: MovieCell, isSelected: Bool)
     
 }
 
-class MovieListCell: UICollectionViewCell {
+class MovieCell: UICollectionViewCell {
     
     // MARK: - Properties
     private let containerStackView: UIStackView = {
@@ -165,7 +165,7 @@ class MovieListCell: UICollectionViewCell {
 }
 
 // MARK: - NameSpaces
-extension MovieListCell {
+extension MovieCell {
     
     private enum Design {
         

--- a/NaverMovieSearch/Presentation/Search/View/MovieListCell.swift
+++ b/NaverMovieSearch/Presentation/Search/View/MovieListCell.swift
@@ -32,6 +32,7 @@ class MovieListCell: UICollectionViewCell {
     private let descriptionStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
+        stackView.distribution = .fillEqually
         return stackView
     }()
     private let titleLabel: UILabel = {
@@ -120,6 +121,10 @@ class MovieListCell: UICollectionViewCell {
         return movie
     }
     
+    func hideTitleLablel() {
+        titleLabel.isHidden = true
+    }
+    
     private func configureUI() {
         self.backgroundColor = .white
         self.addSubview(containerStackView)
@@ -159,6 +164,7 @@ class MovieListCell: UICollectionViewCell {
     
 }
 
+// MARK: - NameSpaces
 extension MovieListCell {
     
     private enum Design {

--- a/NaverMovieSearch/Presentation/Search/View/MovieSearchViewController.swift
+++ b/NaverMovieSearch/Presentation/Search/View/MovieSearchViewController.swift
@@ -14,11 +14,14 @@ final class MovieSearchViewController: UIViewController {
         textField.translatesAutoresizingMaskIntoConstraints = false
         return textField
     }()
-    private var viewModel: MovieSearchViewModel?
-    private let listCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+    private let listCollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewLayout()
+    )
     private let textFieldDidReturn = PublishSubject<String>()
     private let favoriteMovie = PublishSubject<(Movie, Bool)>()
-    private var disposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
+    private var viewModel: MovieSearchViewModel?
     
     // MARK: - Initializers
     convenience init(viewModel: MovieSearchViewModel) {
@@ -53,19 +56,19 @@ final class MovieSearchViewController: UIViewController {
         let favoriteButton: UIButton = {
             let button = UIButton()
             button.backgroundColor = .white
-            button.setImage(UIImage(systemName: "star.fill")?.withRenderingMode(.alwaysTemplate), for: .normal)
+            button.setImage(Design.favoriteButtonImage?.withRenderingMode(.alwaysTemplate), for: .normal)
             button.tintColor = .systemYellow
-            button.setTitle("즐겨찾기", for: .normal)
+            button.setTitle(Design.favoriteButtonTitle, for: .normal)
             button.setTitleColor(.label, for: .normal)
-            button.layer.cornerRadius = 5
-            button.layer.borderWidth = 1
-            button.layer.borderColor = UIColor.systemGray4.cgColor
+            button.layer.cornerRadius = Design.favoriteButtonCornerRadius
+            button.layer.borderWidth = Design.favoriteButtonBorderWidth
+            button.layer.borderColor = Design.favoriteButtonBorderColor
             button.clipsToBounds = true
             button.widthAnchor.constraint(equalToConstant: button.intrinsicContentSize.width + 10).isActive = true
             button.heightAnchor.constraint(equalToConstant: button.intrinsicContentSize.height + 5).isActive = true
             return button
         }()
-        navigationItem.backButtonTitle = ""
+        navigationItem.backButtonTitle = Design.backButtonTitle
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: titleLabel)
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: favoriteButton)
     }
@@ -92,7 +95,7 @@ final class MovieSearchViewController: UIViewController {
     
     private func configureCollectionView() {
         listCollectionView.translatesAutoresizingMaskIntoConstraints = false
-        listCollectionView.register(cellClass: MovieListCell.self)
+        listCollectionView.register(cellClass: MovieCell.self)
         listCollectionView.collectionViewLayout = createCollectionViewLayout()
         listCollectionView.backgroundColor = .systemGray6
     }
@@ -109,7 +112,7 @@ final class MovieSearchViewController: UIViewController {
             item.contentInsets = NSDirectionalEdgeInsets(top: 0.5, leading: 0, bottom: 0.5, trailing: 0)
             
             var groupSize: NSCollectionLayoutSize
-            if screenHeight < 750 {
+            if screenHeight < Design.deviceHeightStandard {
                 groupSize = NSCollectionLayoutSize(
                     widthDimension: .fractionalWidth(1.0),
                     heightDimension: .fractionalHeight(0.2)
@@ -155,8 +158,8 @@ extension MovieSearchViewController {
         movieList
             .bind(to: listCollectionView.rx.items) { collectionView, row, item in
                 guard let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: String(describing: MovieListCell.self),
-                    for: IndexPath(row: row, section: .zero)) as? MovieListCell
+                    withReuseIdentifier: String(describing: MovieCell.self),
+                    for: IndexPath(row: row, section: .zero)) as? MovieCell
                 else {
                     return UICollectionViewCell()
                 }
@@ -176,15 +179,15 @@ extension MovieSearchViewController: MovieListCellDelegate, MovieDetailViewContr
     
     // MovieDetailViewController Delegate
     func starButtonDidTap(at indexPath: IndexPath, isSelected: Bool) {
-        guard let selectedCell = listCollectionView.cellForItem(at: indexPath) as? MovieListCell else { return }
+        guard let selectedCell = listCollectionView.cellForItem(at: indexPath) as? MovieCell else { return }
         
         favoriteMovie.onNext((selectedCell.makeMovieItem(), isSelected))
     }
     
     // MovieListCell Delegate
-    func starButtonDidTap(at cell: MovieListCell, isSelected: Bool) {
+    func starButtonDidTap(at cell: MovieCell, isSelected: Bool) {
         guard let indexPath = listCollectionView.indexPath(for: cell),
-              let selectedCell = listCollectionView.cellForItem(at: indexPath) as? MovieListCell else {
+              let selectedCell = listCollectionView.cellForItem(at: indexPath) as? MovieCell else {
             return
         }
         
@@ -214,6 +217,15 @@ extension MovieSearchViewController {
         
         static let searchTextFieldPlaceHolder = "영화 제목을 검색해보세요!"
         static let titleText = "네이버 영화 검색"
+        
+        static let favoriteButtonImage = UIImage(systemName: "star.fill")
+        static let favoriteButtonTitle = "즐겨찾기"
+        static let favoriteButtonCornerRadius: CGFloat = 5
+        static let favoriteButtonBorderWidth: CGFloat = 1
+        static let favoriteButtonBorderColor = UIColor.systemGray4.cgColor
+        
+        static let backButtonTitle = ""
+        static let deviceHeightStandard: CGFloat = 750
         
     }
     

--- a/NaverMovieSearch/Presentation/Search/ViewModel/MovieSearchViewModel.swift
+++ b/NaverMovieSearch/Presentation/Search/ViewModel/MovieSearchViewModel.swift
@@ -8,6 +8,8 @@ final class MovieSearchViewModel {
         
         let textFieldDidReturn: Observable<String>
         let favoriteMovie: Observable<(Movie, Bool)>
+        let selectedItem: Observable<CellItem>
+        let selectedIndexPath: Observable<IndexPath>
         
     }
     
@@ -19,13 +21,21 @@ final class MovieSearchViewModel {
     
     // MARK: - Properties
     private var favoriteMovies: [Movie] = []
+    private let coordinator: SearchCoordinator?
     private let disposeBag = DisposeBag()
+    
+    // MARK: - Initializers
+    init(coordinator: SearchCoordinator) {
+        self.coordinator = coordinator
+    }
     
     // MARK: - Methods
     func transform(_ input: Input) -> Output {
-        configureFavoriteMovies(with: input.favoriteMovie)
         let movieList = configureMovieList(with: input.textFieldDidReturn)
         let ouput = Output(movieList: movieList)
+        
+        configureFavoriteMovies(with: input.favoriteMovie)
+        configureSelectedCellDetailWith(item: input.selectedItem, indexPath: input.selectedIndexPath)
         
         return ouput
     }
@@ -81,7 +91,16 @@ final class MovieSearchViewModel {
                 }
             })
             .disposed(by: disposeBag)
-            
+    }
+    
+    private func configureSelectedCellDetailWith(item: Observable<CellItem>, indexPath: Observable<IndexPath>) {
+        Observable.zip(item, indexPath)
+            .withUnretained(self)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { (self, cellInformation) in
+                self.coordinator?.showDetailPage(with: cellInformation)
+            })
+            .disposed(by: disposeBag)
     }
     
 }

--- a/NaverMovieSearch/Protocol/CoordinatorDescribing.swift
+++ b/NaverMovieSearch/Protocol/CoordinatorDescribing.swift
@@ -5,6 +5,4 @@ protocol CoordinatorDescribing: AnyObject {
     var childCoordinators: [CoordinatorDescribing] { get set }
     var navigationController: UINavigationController? { get set }
     
-    func start()
-    
 }


### PR DESCRIPTION
# 기능 요약
셀을 선택한 경우 해당 셀에 해당하는 상세화면을 보여줍니다. 
기존 셀에 보였던 간단한 설명과 함께 WebView를 보여줍니다. 

# 작업 내용
## 1. 즐겨찾기를 추가할 수 있는 로직에 대해 고민했습니다. 
DetailView에서도 즐겨찾기를 추가, 삭제할 수 있어야 했습니다. 그래서 기존 Delegate 패턴을 다시 활용하는 방법을 선택했습니다. 
일단 `MovieCell`의 Delegate를 `MovieDetailViewController`가 하도록 하고, 이를 또 `MovieSearchViewController`가 처리해줄 수 있도록 했습니다.
이때 DetailView에서의 Cell의 IndexPath와 ListView에서의 Cell의 Index가 달랐고, 기존 ListView의 IndexPath가 필요했습니다.
```swift
// MovieDetailViewController Delegate
func starButtonDidTap(at indexPath: IndexPath, isSelected: Bool) {
    guard let selectedCell = listCollectionView.cellForItem(at: indexPath) as? MovieCell else { return }
    
    favoriteMovie.onNext((selectedCell.makeMovieItem(), isSelected))
}
```
따라서 `DetailCoordinator`를 통해 Detail 화면으로 전환하는 경우 Cell의 Item과 IndexPath를 `Zip`을 통해 묶어서 보낼 수 있도록 했습니다. 

이를 통해 DetailView에서 즐겨찾기 버튼을 누르더라도 즐겨찾기 목록에 추가 / 삭제가 가능할 수 있도록 했습니다. 

또한 DetailView에서 `Back Button`을 누르는 경우 collectionView가 refresh되어야 했기에 `viewWillAppear`에 `listCollectionView`를 `reloadData()`해줬습니다. 


## 2. `MovieDetailViewController`가 종료되면 메모리에서 DetailCoordinator도 내려가도록 했습니다. 
화면을 `Back Button`을 통해 `Pop`하더라도 기존 `SearchCoordinator`의 `childCoordinators` 배열에 append가 되어 있어 `DetailCoordinator`가 메모리에서 내려오지 않는 문제가 있었습니다. 

따라서 ViewModel에서 `BackButton`을 탭했을 때 `DetailCoordinator`의 `finish` 메서드를 호출하여 기존 배열에서 제거해주려고 했으나 
`navigationItem.backBarButtonItem`이 계속 nil이 나오는 문제점이 있었습니다. 이를 해결하기 위해 기존 `MovieSearchViewController`에서 `bactBarButtonItem`을 넘겨줬지만 `BackButton`을 탭했는지 확인할 수 없었습니다. 

`BackButton`을 누르게 되면 `popViewController`가 되면서 기존에 떠있던 ViewController이 deinit이 되기 때문에 여기서 `DetailCoordinator`의 `finish` 메서드를 호출하도록 방법을 변경했습니다. 

## 3. WebView를 통해 Link에 해당하는 내용을 보여줬습니다. 
기존 받아오는 Data에 해당 영화에 대한 Link도 받을 수 있었습니다. 따라서 `WKWebView`를 사용해 이를 보여줄 수 있도록 했습니다. 
이미 iOS 12.0에서 Deprecated된 `UIWebView`의 경우 성능상(렌더링 가능 수가 2배 이상 차이)으로도 떨어지고 이미 사용할 수 없어 고려 대상에서 제외했고, `SFSafariViewController`의 경우 아예 사파리를 실행해서 보여주기 때문에 `WKWebView`이 가장 적합하다고 판단했습니다. 

그래서 Link를 URLRequest로 변경하여 WKWebView의 load 메서드를 활용하려 했으나 다음과 같은 에러가 발생했습니다. 

>WebPageProxy::didFailProvisionalLoadForFrame: frameID = 3, domain = NSURLErrorDomain, code = -1022

따라서 Info.plist에서 `App Transport Security Settings` > `Allow Arbitary Loads`를 `YES`로 추가해주었습니다. 

# 스크린샷
<img src="https://user-images.githubusercontent.com/90880660/173991864-e9839a70-3ce3-4236-b5c7-266a5417d9b1.gif" width=250>

